### PR TITLE
feat: Validate API Secret type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,6 @@ jobs:
         env:
           INFERABLE_API_ENDPOINT: 'https://api.inferable.ai'
           INFERABLE_CLUSTER_ID: ${{ vars.INFERABLE_CLUSTER_ID }}
-          INFERABLE_MACHINE_KEY: ${{ secrets.INFERABLE_MACHINE_KEY }}
-          INFERABLE_CONSUME_KEY: ${{ secrets.INFERABLE_CONSUME_KEY }}
+          INFERABLE_MACHINE_SECRET: ${{ secrets.INFERABLE_MACHINE_SECRET }}
+          INFERABLE_CONSUME_SECRET: ${{ secrets.INFERABLE_CONSUME_SECRET }}
 

--- a/src/Inferable.test.ts
+++ b/src/Inferable.test.ts
@@ -1,6 +1,12 @@
 import { z } from "zod";
 import { Inferable } from "./Inferable";
-import { TEST_CLUSTER_ID, client, inferableInstance } from "./tests/utils";
+import {
+  TEST_CLUSTER_ID,
+  TEST_CONSUME_SECRET,
+  TEST_MACHINE_SECRET,
+  client,
+  inferableInstance,
+} from "./tests/utils";
 
 const testService = () => {
   const inferable = inferableInstance();
@@ -47,24 +53,30 @@ describe("Inferable", () => {
   });
 
   it("should initialize without optional args", () => {
-    expect(() => new Inferable({ apiSecret: "test" })).not.toThrow();
+    expect(
+      () => new Inferable({ apiSecret: TEST_MACHINE_SECRET }),
+    ).not.toThrow();
+  });
+
+  it("should initialize with API secret in environment", () => {
+    process.env.INFERABLE_API_SECRET = TEST_MACHINE_SECRET;
+    expect(() => new Inferable()).not.toThrow();
   });
 
   it("should throw if no API secret is provided", () => {
     expect(() => new Inferable()).toThrow();
   });
 
-  it("should initialize with API secret in environment", () => {
-    process.env.INFERABLE_API_SECRET = "environment_secret";
-    expect(() => new Inferable()).not.toThrow();
-    const d = new Inferable();
-    expect(d.secretPartial).toBe("envi...");
+  it("should throw if invalid API secret is provided", () => {
+    expect(() => new Inferable({ apiSecret: "invalid" })).toThrow();
+  });
+
+  it("should throw if incorrect API secret is provided", () => {
+    expect(() => new Inferable({ apiSecret: TEST_CONSUME_SECRET })).toThrow();
   });
 
   it("should register a function", async () => {
-    const d = new Inferable({
-      apiSecret: "fake",
-    });
+    const d = inferableInstance();
 
     const echo = async (param: { foo: string }) => {
       return param.foo;

--- a/src/Inferable.test.ts
+++ b/src/Inferable.test.ts
@@ -47,7 +47,7 @@ describe("Inferable", () => {
   });
 
   it("should initialize without optional args", () => {
-    expect(() => new Inferable({ apiKey: "test" })).not.toThrow();
+    expect(() => new Inferable({ apiSecret: "test" })).not.toThrow();
   });
 
   it("should throw if no API secret is provided", () => {
@@ -58,12 +58,12 @@ describe("Inferable", () => {
     process.env.INFERABLE_API_SECRET = "environment_secret";
     expect(() => new Inferable()).not.toThrow();
     const d = new Inferable();
-    expect(d.keyPartial).toBe("envi...");
+    expect(d.secretPartial).toBe("envi...");
   });
 
   it("should register a function", async () => {
     const d = new Inferable({
-      apiKey: "fake",
+      apiSecret: "fake",
     });
 
     const echo = async (param: { foo: string }) => {

--- a/src/Inferable.ts
+++ b/src/Inferable.ts
@@ -303,10 +303,6 @@ export class Inferable {
     return this.services[0]?.clusterId || null;
   }
 
-  public get secretPartial() {
-    return (this.apiSecret || "").substring(0, 4) + "...";
-  }
-
   private registerFunction<T extends z.ZodTypeAny | JsonSchemaInput>({
     name,
     authenticate,

--- a/src/Inferable.ts
+++ b/src/Inferable.ts
@@ -41,7 +41,9 @@ export const log = debug("inferable:client");
  * // src/service.ts
  *
  * // create a new Inferable instance
- * const d = new Inferable("API_SECRET");
+ * const d = new Inferable({
+ *  apiSecret: "API_SECRET",
+ * });
  *
  * const myService = d.service({
  *   name: "my-service",
@@ -70,7 +72,7 @@ export class Inferable {
     return require(path.join(__dirname, "..", "package.json")).version;
   }
 
-  private apiKey: string;
+  private apiSecret: string;
   private endpoint: string;
   private machineId: string;
 
@@ -107,25 +109,37 @@ export class Inferable {
    * ```
    */
   constructor(options?: {
-    apiKey?: string;
+    apiSecret?: string;
     endpoint?: string;
     jobPollWaitTime?: number;
   }) {
-    if (options?.apiKey && process.env.INFERABLE_API_SECRET) {
+    if (options?.apiSecret && process.env.INFERABLE_API_SECRET) {
       log(
         "API Secret was provided as an option and environment variable. Constructor argument will be used.",
       );
     }
 
-    const apiKey = options?.apiKey || process.env.INFERABLE_API_SECRET;
+    const apiSecret = options?.apiSecret || process.env.INFERABLE_API_SECRET;
 
-    if (!apiKey) {
+    if (!apiSecret) {
       throw new InferableError(
-        `No API Key provided. Please see ${links.DOCS_AUTH}`,
+        `No API Secret provided. Please see ${links.DOCS_AUTH}`,
       );
     }
 
-    this.apiKey = apiKey;
+    if (!apiSecret.startsWith("sk_cluster_machine")) {
+      if (apiSecret.startsWith("sk_")) {
+        throw new InferableError(
+          `Provided non-Machine API Secret. Please see ${links.DOCS_AUTH}`,
+        );
+      }
+
+      throw new InferableError(
+        `Invalid API Secret. Please see ${links.DOCS_AUTH}`,
+      );
+    }
+
+    this.apiSecret = apiSecret;
 
     this.endpoint =
       options?.endpoint ||
@@ -256,7 +270,7 @@ export class Inferable {
         const serivce = new Service({
           endpoint: this.endpoint,
           machineId: this.machineId,
-          apiKey: this.apiKey,
+          apiSecret: this.apiSecret,
           service: input.name,
           functions: Object.values(this.functionRegistry).filter(
             (f) => f.serviceName == input.name,
@@ -289,8 +303,8 @@ export class Inferable {
     return this.services[0]?.clusterId || null;
   }
 
-  public get keyPartial() {
-    return (this.apiKey || "").substring(0, 4) + "...";
+  public get secretPartial() {
+    return (this.apiSecret || "").substring(0, 4) + "...";
   }
 
   private registerFunction<T extends z.ZodTypeAny | JsonSchemaInput>({

--- a/src/service.ts
+++ b/src/service.ts
@@ -30,7 +30,7 @@ export class Service {
   constructor(options: {
     endpoint: string;
     machineId: string;
-    apiKey: string;
+    apiSecret: string;
     service: string;
     functions: FunctionRegistration[];
   }) {
@@ -39,7 +39,7 @@ export class Service {
     this.client = createApiClient({
       baseUrl: options.endpoint,
       machineId: options.machineId,
-      apiSecret: options.apiKey,
+      apiSecret: options.apiSecret,
     });
 
     this.functions = options.functions;

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -11,11 +11,11 @@ if (
   throw new Error("Test environment variables not set");
 }
 
+export const TEST_ENDPOINT = process.env.INFERABLE_API_ENDPOINT;
 export const TEST_CLUSTER_ID = process.env.INFERABLE_CLUSTER_ID;
 
-const TEST_ENDPOINT = process.env.INFERABLE_API_ENDPOINT;
-const TEST_MACHINE_SECRET = process.env.INFERABLE_MACHINE_SECRET;
-const TEST_CONSUME_SECRET = process.env.INFERABLE_CONSUME_SECRET;
+export const TEST_MACHINE_SECRET = process.env.INFERABLE_MACHINE_SECRET;
+export const TEST_CONSUME_SECRET = process.env.INFERABLE_CONSUME_SECRET;
 
 console.log("Testing with", {
   TEST_ENDPOINT,

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -3,19 +3,19 @@ import { initClient } from "@ts-rest/core";
 import { contract } from "../contract";
 
 if (
-  !process.env.INFERABLE_MACHINE_KEY ||
-  !process.env.INFERABLE_CONSUME_KEY ||
+  !process.env.INFERABLE_MACHINE_SECRET ||
+  !process.env.INFERABLE_CONSUME_SECRET ||
   !process.env.INFERABLE_API_ENDPOINT ||
   !process.env.INFERABLE_CLUSTER_ID
 ) {
   throw new Error("Test environment variables not set");
 }
 
-export const TEST_ENDPOINT = process.env.INFERABLE_API_ENDPOINT;
 export const TEST_CLUSTER_ID = process.env.INFERABLE_CLUSTER_ID;
 
-export const TEST_MACHINE_KEY = process.env.INFERABLE_MACHINE_KEY;
-export const TEST_CONSUME_KEY = process.env.INFERABLE_CONSUME_KEY;
+const TEST_ENDPOINT = process.env.INFERABLE_API_ENDPOINT;
+const TEST_MACHINE_SECRET = process.env.INFERABLE_MACHINE_SECRET;
+const TEST_CONSUME_SECRET = process.env.INFERABLE_CONSUME_SECRET;
 
 console.log("Testing with", {
   TEST_ENDPOINT,
@@ -25,13 +25,13 @@ console.log("Testing with", {
 export const client = initClient(contract, {
   baseUrl: TEST_ENDPOINT,
   baseHeaders: {
-    authorization: `${TEST_CONSUME_KEY}`,
+    authorization: `${TEST_CONSUME_SECRET}`,
   },
 });
 
 export const inferableInstance = () =>
   new Inferable({
-    apiKey: TEST_MACHINE_KEY,
+    apiSecret: TEST_MACHINE_SECRET,
     endpoint: TEST_ENDPOINT,
     jobPollWaitTime: 5000,
   });


### PR DESCRIPTION
- Revert to `apiSecret` usage
- Validate that the provided Secret is a `Machine` type