### PR TITLE
feat: Wrap non-http-errors

### DIFF
--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -21,12 +21,20 @@ export const createApiClient = ({
       ...(apiSecret ? { authorization: apiSecret } : {}),
       ...(machineId ? { "x-machine-id": machineId } : {}),
     },
-    api: clientAbortController
-      ? (args) => {
-          return tsRestFetchApi({
-            ...args,
-            signal: clientAbortController.signal,
-          });
-        }
-      : undefined,
+    api: async (args) => {
+      try {
+        return await tsRestFetchApi({
+          ...args,
+          ...(clientAbortController
+            ? { signal: clientAbortController.signal }
+            : {}),
+        });
+      } catch (e) {
+        return {
+          status: -1,
+          headers: new Headers(),
+          body: e,
+        };
+      }
+    },
   });


### PR DESCRIPTION
Wrap non-http (i.e connection errors) in the same error format.

This means that we only need to handle one type of error response from `client`:

```
    const registerResult = await this.client.createMachine({
    ....
    });

    if (registerResult?.status !== 200) {
      log("Failed to register machine", registerResult);
    }
```


Rather than:


```
    try {
      const registerResult = await this.client.createMachine({
      ....
      });
      
      if (registerResult?.status !== 200) {
        log("Failed to register machine", registerResult);
      }
   } catch(e) {
    log("Failed to register machine", e);
   }


```